### PR TITLE
Docs: Move charts docs out of 'Charts' category

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -1,4 +1,4 @@
 [module]
 [[module.mounts]]
-source = ""
+source = "Charts"
 target = "content/docs"


### PR DESCRIPTION
Flatten Charts documentation so Deployment, Operations, etc are top level entries in the nav tree

This will break the "Edit this page", etc links for charts doc pages, this is something I need to fix in the main docs repo.