### PR TITLE
use networking.k8s.io/v1beta1 Ingress for Kubernetes version before v…

### DIFF
--- a/releases/ctp/templates/ingress.yaml
+++ b/releases/ctp/templates/ingress.yaml
@@ -1,9 +1,40 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "ctp.fullname" . -}}
 {{- $svcPort := .Values.services.web.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.14-0 <=1.21-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "ctp.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ . | quote }}
+      http:
+        paths:
+          - path: "/"
+            backend:
+              serviceName: {{ $fullName }}-web
+              servicePort: {{ $svcPort }}
+    {{- end }}
+{{- else if semverCompare ">=1.22-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1
-{{- end }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -37,4 +68,8 @@ spec:
                 port: 
                   number: {{ $svcPort }}
     {{- end }}
-  {{- end }}
+{{- else }}
+{{- end }}
+{{- end }}
+
+


### PR DESCRIPTION
Use older Ingress Apigroup version for AWS Load Balancer Controller v.2.3 and its previous versions, while waiting for this controller to be updated to work with networking.k8s.io/v1 Ingress