### PR TITLE
Docs: Reformat Linode-setup + change some page titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,4 +41,4 @@ helm upgrade ctp ais/ctp --install --values ./my-ctp-site-overrides.yaml --names
 watch kubectl -nctp get all
 ```
 
-For more information refer to the [AIS Charts Documentation](https://australian-imaging-service.github.io/charts/)
+For more information refer to the [AIS Dev Documentation](https://australian-imaging-service.github.io/docs/)

--- a/docs/Charts/Deployment/ALB-Ingress-Controller.md
+++ b/docs/Charts/Deployment/ALB-Ingress-Controller.md
@@ -10,10 +10,10 @@ We will be following this AWS Guide:
 https://docs.aws.amazon.com/eks/latest/userguide/alb-ingress.html
  
 {{% alert title="Before we begin" %}}
-One thing that you need to know when we want to create new ALB from EKS is service spec type can only support LoadBalancer and NodePort. It won't support ClusterIP.
+One thing that you need to know when we want to create new ALB from EKS is service spec type can only support LoadBalancer and NodePort. It won't support `ClusterIP`.
 {{% /alert %}}
 
-The Charts Repo has the service defined as ClusterIP so some changes need to be made to make this work. We will get to that later after we have created the ALB and policies.
+The Charts Repo has the service defined as `ClusterIP` so some changes need to be made to make this work. We will get to that later after we have created the ALB and policies.
 
 In this document we create a Cluster called xnat in ap-southeast-2. Please update these details for your environment.
  
@@ -90,7 +90,7 @@ Commented out / removed:
       nginx.ingress.kubernetes.io/proxy-buffer-size: "32k"
 ``` 
  
-As pointed out ClusterIP as service type does not work with ALB. So you will have to make some further changes to `charts/xnat/charts/xnat-web/values.yaml`:
+As pointed out `ClusterIP` as service type does not work with ALB. So you will have to make some further changes to `charts/xnat/charts/xnat-web/values.yaml`:
 
 Change:
 ```yaml
@@ -119,7 +119,7 @@ helm upgrade xnat . -nxnat
 
 It should now create a Target Group and Application Load Balancer in AWS EC2 Services. I had to make a further change to get this to work.
  
-On the Target Group I had to change health check code from 200 to 302 to get a healthy instance because it redirects.
+On the Target Group I had to change health check code from **`200`** to **`302`** to get a healthy instance because it redirects.
  
 You can fix this by adding the following line to values file:  
 ```yaml

--- a/docs/Charts/Deployment/Azure-Setup-Full.md
+++ b/docs/Charts/Deployment/Azure-Setup-Full.md
@@ -15,12 +15,12 @@ Specify your Resource Group, cluster name (in our case xnat but please update if
 
 ```bash
 az aks create \
---resource-group <Resource Group Name> \
---name xnat \
---node-count 3 \
---generate-ssh-keys \
---node-vm-size Standard_B2s \
---enable-managed-identity
+  --resource-group <Resource Group Name> \
+  --name xnat \
+  --node-count 3 \
+  --generate-ssh-keys \
+  --node-vm-size Standard_B2s \
+  --enable-managed-identity
 ```
 
 

--- a/docs/Charts/Deployment/Linode-setup.md
+++ b/docs/Charts/Deployment/Linode-setup.md
@@ -1,183 +1,250 @@
-**List of steps to be followed to deploy XNAT in Linode LKE using Helm charts**
+---
+title: "Linode setup"
+weight: 10
+---
 
+List of steps to be followed to deploy XNAT in Linode LKE using Helm charts
 
-         
+### 1. LKE Cluster Setup
 
-**1.LKE Cluster Setup:**\
-                                    Set up the Linode LKE cluster using the link https://www.linode.com/docs/guides/how-to-deploy-an-lke-cluster-using-terraform/ **(Please note that a separate documentation for setting up LKE Cluster using Terraform will be coming up soon)**
+Set up the Linode LKE cluster using the link https://www.linode.com/docs/guides/how-to-deploy-an-lke-cluster-using-terraform/
 
-**2.Preparing for Tweaks pertaining to Linode:**\
-                           As we are tweaking XNAT Values related to PV access modes, let us check out the charts repo rather than using the adding
-AIS helm chart repository.
-                          
-         git clone https://github.com/Australian-Imaging-Service/charts.git
+{{% alert %}}
+Please note that a separate documentation for setting up LKE Cluster using Terraform will be coming up soon
+{{% /alert %}}
 
-**3.Actual Tweaks:**\
-                           Replace the access modes of all Volumes from "ReadWriteMany" to "ReadWriteOnce" in charts/releases/xnat/charts/xnat-web
-This is because Linode storage only supports "ReadWriteOnce" at this point of time.
+### 2. Preparing for Tweaks pertaining to Linode
 
-**4.Dependency Update:**\
-                           Update the dependency by switching to charts/releases/xnat and execute the following
-            
-         helm dependency update
+As we are tweaking XNAT Values related to PV access modes, let us check out the charts repo rather than using the AIS helm chart repository.
 
-**5.XNAT Initial Installation:**\
-                           Go to charts/releases and install xnat using helm.
+```bash
+git clone https://github.com/Australian-Imaging-Service/charts.git
+```
 
-           kubectl create namespace xnat
+### 3. Actual Tweaks
 
-           helm install xnat-deployment xnat --values YOUR-VALUES-FILE --namespace=xnat
+Replace the access modes of all Volumes from `ReadWriteMany` to `ReadWriteOnce` in `charts/releases/xnat/charts/xnat-web`
 
-   The XNAT & POSTGRES service should be up & running fine. Linode Storage Class "linode-block-storage-retain" should have automatically
-   come in place & PVs will be auto created to be consumed by our mentioned PVCs.
+This is because Linode storage only supports `ReadWriteOnce` at this point of time.
 
-**6.Ingress Controller/Load balancer Installation:**\
-                           Install Ingress Controller and provision a Load balancer (Nodebalancer in Linode) by executing these commands
+### 4. Dependency Update
 
-            helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+Update the dependency by switching to `charts/releases/xnat` and execute the following
 
-            helm repo update
+```bash
+helm dependency update
+```
 
-            helm install ingress-nginx ingress-nginx/ingress-nginx
+### 5. XNAT Initial Installation
+
+Go to `charts/releases` and install xnat using helm.
+
+```bash
+kubectl create namespace xnat
+
+helm install xnat-deployment xnat --values YOUR-VALUES-FILE --namespace=xnat
+```
+
+The XNAT & POSTGRES service should be up and running fine. Linode Storage Class `linode-block-storage-retain` should have automatically
+come in place & PVs will be auto created to be consumed by our mentioned PVCs.
+
+### 6. Ingress Controller/Load balancer Installation
+
+Install Ingress Controller and provision a Load balancer (Nodebalancer in Linode) by executing these commands
+
+```bash
+helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+
+helm repo update
+
+helm install ingress-nginx ingress-nginx/ingress-nginx
+```
 
 You may see an output like below
 
->NAME: ingress-nginx\
-LAST DEPLOYED: Mon Aug  2 11:51:32 2021\
-NAMESPACE: default\
-STATUS: deployed\
-REVISION: 1\
-TEST SUITE: None\
-NOTES:\
-The ingress-nginx controller has been installed.\
+```
+>NAME: ingress-nginx
+LAST DEPLOYED: Mon Aug  2 11:51:32 2021
+NAMESPACE: default
+STATUS: deployed
+REVISION: 1
+TEST SUITE: None
+NOTES:
+The ingress-nginx controller has been installed.
 It may take a few minutes for the LoadBalancer IP to be available.
+```
 
-**7.Domain Mapping:**\
-                           Get the External IP address of the Loadbalancer by running the below command and assign it to any domain or subdomain.
-  > **Example: cloud.neura.edu.au is the subdomain for which the loadbalancer IP is assigned in my case. Please replace it with your domain in this and all upcoming steps**
+### 7. Domain Mapping
 
-            kubectl --namespace default get services -o wide -w ingress-nginx-controller
+Get the External IP address of the Loadbalancer by running the below command and assign it to any domain or subdomain.
 
-**8.HTTP Traffic Routing via Ingress:**\
-                           It is time to create a Ingress object that directs the traffic based on the host/domain to the already available XNAT service.
-   Get the XNAT service name by issuing the below command and choose the service name that says TYPE as ClusterIP
+{{% alert %}}
+**Example:** `cloud.neura.edu.au` is the subdomain for which the loadbalancer IP is assigned in my case.
+Please replace it with your domain in this and all upcoming steps
+{{% /alert %}}
 
-          kubectl get svc -nxnat -l "app.kubernetes.io/name=xnat-web"
+```bash
+kubectl --namespace default get services -o wide -w ingress-nginx-controller
+```
 
-   Example: xnat-deployment-xnat-web
+### 8. HTTP Traffic Routing via Ingress
 
-   Using the above service name, write an ingress object to route the external traffic based on the domain name.
+It is time to create a Ingress object that directs the traffic based on the host/domain to the already available XNAT service.
 
-         apiVersion: networking.k8s.io/v1
-         kind: Ingress
-         metadata:
-           name: xnat-ingress
-           namespace: xnat
-           annotations:
-             kubernetes.io/ingress.class: nginx
-         spec:
-           rules:
-           - host: cloud.neura.edu.au
-             http:
-               paths:
-               - pathType: Prefix
-                 path: "/"
-                 backend:
-                   service:
-                     name: xnat-deployment-xnat-web
-                     port:
-                       number: 80
+Get the XNAT service name by issuing the below command and choose the service name that says TYPE as `ClusterIP`
 
-**9.Delete the HTTP Ingress project:**\
-                           After the creation of this Ingress object, make sure cloud.neura.edu.au is routed to the XNAT application over HTTP successfully.Let us delete the ingress object after checking because we will be creating another one with TLS to use HTTPS.
+```bash
+kubectl get svc -nxnat -l "app.kubernetes.io/name=xnat-web"
+```
 
-        kubectl delete ingress xnat-ingress -nxnat
+Example: `xnat-deployment-xnat-web`
 
-**10.Install cert-manager for Secure Connection HTTPS**\
-                           Install cert-manager’s CRDs.
+Using the above service name, write an ingress object to route the external traffic based on the domain name.
 
-         kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.3.1/cert-manager.crds.yaml
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: xnat-ingress
+  namespace: xnat
+  annotations:
+    kubernetes.io/ingress.class: nginx
+spec:
+  rules:
+  - host: cloud.neura.edu.au
+    http:
+      paths:
+      - pathType: Prefix
+        path: "/"
+        backend:
+          service:
+            name: xnat-deployment-xnat-web
+            port:
+              number: 80
+```
 
-Create a cert-manager namespace.
+### 9. Delete the HTTP Ingress project
 
-         kubectl create namespace cert-manager
-Add the Helm repository which contains the cert-manager Helm chart.
+After the creation of this Ingress object, make sure `cloud.neura.edu.au` is routed to the XNAT application over HTTP successfully.Let us delete the ingress object after checking because we will be creating another one with TLS to use HTTPS.
 
-         helm repo add jetstack https://charts.jetstack.io
+```bash
+kubectl delete ingress xnat-ingress -nxnat
+```
+
+### 10. Install cert-manager for Secure Connection HTTPS
+
+Install `cert-manager`'s CRDs.
+
+```bash
+kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.3.1/cert-manager.crds.yaml
+```
+
+Create a `cert-manager` namespace.
+
+```bash
+kubectl create namespace cert-manager
+```
+
+Add the Helm repository which contains the `cert-manager` Helm chart.
+
+```bash
+helm repo add jetstack https://charts.jetstack.io
+```
+
 Update your Helm repositories.
 
-         helm repo update
-Install the cert-manager Helm chart.
+```bash
+helm repo update
+```
 
-         helm install \
-         cert-manager jetstack/cert-manager \
-         --namespace cert-manager \
-         --version v1.3.1
-Verify that the corresponding cert-manager pods are now running.
+Install the `cert-manager` Helm chart.
 
-         kubectl get pods --namespace cert-manager
+```bash
+helm install \
+  cert-manager jetstack/cert-manager \
+  --namespace cert-manager \
+  --version v1.3.1
+```
+
+Verify that the corresponding `cert-manager` pods are now running.
+
+```bash
+kubectl get pods --namespace cert-manager
+```
+
 You should see a similar output:
 
->NAME                                       READY   STATUS    RESTARTS   AGE\
-cert-manager-579d48dff8-84nw9              1/1     Running   3          1m\
-cert-manager-cainjector-789955d9b7-jfskr   1/1     Running   3          1m\
+```
+>NAME                                       READY   STATUS    RESTARTS   AGE
+cert-manager-579d48dff8-84nw9              1/1     Running   3          1m
+cert-manager-cainjector-789955d9b7-jfskr   1/1     Running   3          1m
 cert-manager-webhook-64869c4997-hnx6n      1/1     Running   0          1m
+```
 
-**11.Creation of ClusterIssuer to Issue certificates:**\
-                           Create a manifest file named acme-issuer-prod.yaml that will be used to create a ClusterIssuer resource on your cluster. Ensure you replace user@example.com with your own email address.
+### 11. Creation of ClusterIssuer to Issue certificates
 
-         
-         apiVersion: cert-manager.io/v1
-         kind: ClusterIssuer
-         metadata:
-           name: letsencrypt-prod
-           namespace: xnat
-         spec:
-           acme:
-             email: user@example.com
-             server: https://acme-v02.api.letsencrypt.org/directory
-             privateKeySecretRef:
-               name: letsencrypt-secret-prod
-             solvers:
-             - http01:
-                 ingress:
-                   class: nginx
+Create a manifest file named `acme-issuer-prod.yaml` that will be used to create a `ClusterIssuer` resource on your cluster. Ensure you replace `user@example.com` with your own email address.
 
-**12.HTTPS Routing with Ingress object leveraging ClusterIssuer:**\
-Provision a new Ingress object to use the clusterIssuer for the generation of the certificate and use it
+```yaml
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+  namespace: xnat
+spec:
+  acme:
+    email: user@example.com
+    server: https://acme-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      name: letsencrypt-secret-prod
+    solvers:
+    - http01:
+        ingress:
+          class: nginx
+```
 
-         apiVersion: networking.k8s.io/v1
-         kind: Ingress
-         metadata:
-           name: xnat-ingress-https
-           namespace: xnat
-           annotations:
-             kubernetes.io/ingress.class: "nginx"
-             cert-manager.io/cluster-issuer: "letsencrypt-prod"
-         spec:
-           tls:
-           - hosts:
-             - cloud.neura.edu.au
-             secretName: xnat-tls
-           rules:
-           - host: cloud.neura.edu.au
-             http:
-               paths:
-               - pathType: Prefix
-                 path: "/"
-                 backend:
-                   service:
-                     name: xnat-deployment-xnat-web
-                     port:
-                       number: 80
+### 12. HTTPS Routing with Ingress object leveraging ClusterIssuer
+
+Provision a new Ingress object to use the `clusterIssuer` for the generation of the certificate and use it
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: xnat-ingress-https
+  namespace: xnat
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+spec:
+  tls:
+  - hosts:
+    - cloud.neura.edu.au
+    secretName: xnat-tls
+  rules:
+  - host: cloud.neura.edu.au
+    http:
+      paths:
+      - pathType: Prefix
+        path: "/"
+        backend:
+          service:
+            name: xnat-deployment-xnat-web
+            port:
+              number: 80
+```
+
+After the creation of the above ingress `https://cloud.neura.edu.au/` should bring up the XNAT application in the web browser
 
 
-After the creation of the above ingress https://cloud.neura.edu.au/ should bring up the XNAT application in the web browser
-
-
-**Reference Links**\
-         LKE set up using Cloud Manager   - https://www.linode.com/docs/guides/deploy-and-manage-a-cluster-with-linode-kubernetes-engine-a-tutorial/ \
-         LKE set up using Terraform       - https://www.linode.com/docs/guides/how-to-deploy-an-lke-cluster-using-terraform/ \
-         Linode Storage Class             - https://www.linode.com/docs/guides/deploy-volumes-with-the-linode-block-storage-csi-driver/ \
-         Ingress Controller & Loadbalancer- https://www.linode.com/docs/guides/how-to-deploy-nginx-ingress-on-linode-kubernetes-engine/ \
-         HTTP to HTTPS using cert-manager - https://www.linode.com/docs/guides/how-to-configure-load-balancing-with-tls-encryption-on-a-kubernetes-cluster
+## Reference Links
+* LKE set up using Cloud Manager\
+  https://www.linode.com/docs/guides/deploy-and-manage-a-cluster-with-linode-kubernetes-engine-a-tutorial/
+* LKE set up using Terraform\
+  https://www.linode.com/docs/guides/how-to-deploy-an-lke-cluster-using-terraform/
+* Linode Storage Class\
+  https://www.linode.com/docs/guides/deploy-volumes-with-the-linode-block-storage-csi-driver/
+* Ingress Controller & Loadbalancer\
+  https://www.linode.com/docs/guides/how-to-deploy-nginx-ingress-on-linode-kubernetes-engine/
+* HTTP to HTTPS using cert-manager\
+  https://www.linode.com/docs/guides/how-to-configure-load-balancing-with-tls-encryption-on-a-kubernetes-cluster

--- a/docs/Charts/Development/macos-multipass-k8s.md
+++ b/docs/Charts/Development/macos-multipass-k8s.md
@@ -1,5 +1,5 @@
 ---
-linktitle: "MacOS+Multipass"
+linktitle: "MacOS: Multipass"
 title: "Development workstation with Multipass on MacOS"
 author: "Fang Xu <xu.fang@sydney.edu.au>"
 weight: 10

--- a/docs/Charts/Development/nixos-minikube.md
+++ b/docs/Charts/Development/nixos-minikube.md
@@ -1,5 +1,5 @@
 ---
-title: "NixOS + Minikube"
+title: "NixOS: Minikube"
 author: "Zane Iperen"
 weight: 10
 ---
@@ -22,7 +22,7 @@ pkgs.mkShell {
     . <(minikube completion bash)
     . <(helm completion bash)
 
-    # kubectk and docker completion require the control plane to be running
+    # kubectl and docker completion require the control plane to be running
     if [ $(minikube status -o json | jq -r .Host) = "Running" ]; then
             . <(kubectl completion bash)
             . <(minikube -p minikube docker-env)

--- a/docs/Charts/Development/references.md
+++ b/docs/Charts/Development/references.md
@@ -1,6 +1,6 @@
 ---
 title: References
-weight: 10
+weight: 20
 ---
 
 ## References (Must reads!)

--- a/docs/Charts/Development/ubuntu-microk8s.md
+++ b/docs/Charts/Development/ubuntu-microk8s.md
@@ -1,5 +1,5 @@
 ---
-title: "microk8s-Ubuntu"
+title: "Ubuntu: microk8s"
 weight: 10
 ---
 

--- a/docs/Charts/Development/windows10-multipass-k8s.md
+++ b/docs/Charts/Development/windows10-multipass-k8s.md
@@ -1,5 +1,5 @@
 ---
-title: "Windows 10+Multipass"
+title: "Windows 10: Multipass"
 author: "Dean Taylor <dean.taylor@uwa.edu.au>"
 weight: 10
 ---

--- a/docs/Charts/Operations/Docker-Swarm-with-XNAT.md
+++ b/docs/Charts/Operations/Docker-Swarm-with-XNAT.md
@@ -1,5 +1,5 @@
 ---
-title: "Docker-Swarm-with-XNAT"
+title: "Docker Swarm with XNAT"
 weight: 10
 ---
 

--- a/docs/Charts/Operations/External-PGSQL-DB-Connection.md
+++ b/docs/Charts/Operations/External-PGSQL-DB-Connection.md
@@ -1,5 +1,5 @@
 ---
-title: "External-PGSQL-DB-Connection"
+title: "External PGSQL DB Connection"
 weight: 10
 ---
 
@@ -135,10 +135,10 @@ Usual string:
 `datasource.url=jdbc:postgresql://xnat-postgresql/yourdatabase`
 
 Options:  
-| Option | Description |
-|--------|-------------|
-| `ssl=true` | use SSL encryption |
-| `sslmode=require` | require SSL encryption |
+| Option                                               | Description                                        |
+|------------------------------------------------------|----------------------------------------------------|
+| `ssl=true`                                           | use SSL encryption                                 |
+| `sslmode=require`                                    | require SSL encryption                             |
 | `sslfactory=org.postgresql.ssl.NonValidatingFactory` | Do not require validation of Certificate Authority |
 
 The last option is useful as otherwise you will need to import the CA cert into your Java keystone on the docker container.  


### PR DESCRIPTION
* `Deployment/Linode-setup.md` was missed during the initial conversion to Hugo docs, oops!
* Unify format of some page titles
* Minor formatting changes