### PR TITLE
resolves #99 and other fixes and enhancements

### DIFF
--- a/releases/xnat/.gitignore
+++ b/releases/xnat/.gitignore
@@ -1,2 +1,3 @@
 /charts/*
 !/charts/xnat-web/
+/tmp/

--- a/releases/xnat/Chart.yaml
+++ b/releases/xnat/Chart.yaml
@@ -24,6 +24,8 @@ appVersion: 1.8.4.1
 
 dependencies:
 - name: postgresql
-  version: "~10.9.4"
+  version: "~10.16.2"
   repository: "https://charts.bitnami.com/bitnami"
   condition: postgresql.enabled
+- name: xnat-web
+  condition: xnat-web.enabled

--- a/releases/xnat/charts/xnat-web/templates/pvc.yaml
+++ b/releases/xnat/charts/xnat-web/templates/pvc.yaml
@@ -1,7 +1,7 @@
 {{- $context := . -}}
 {{- range $name, $c := .Values.volumes }}
 {{- if .existingClaim }}
-{{- else }}
+{{- else if .size }}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/releases/xnat/charts/xnat-web/templates/statefulset.yaml
+++ b/releases/xnat/charts/xnat-web/templates/statefulset.yaml
@@ -87,8 +87,13 @@ spec:
             {{- end }}
             {{- end }}
             {{- range $name, $c := .Values.volumes }}
+            {{- if $c.size }}
             - mountPath: {{ $c.mountPath | quote }}
               name: {{ $name | quote }}
+              {{- if $c.mountPropagation }}
+              mountPropagation: {{$c.mountPropagation|default "None"|quote}}
+              {{- end }}
+            {{- end }}
             {{- end }}
       initContainers:
         - name: home-init
@@ -151,9 +156,11 @@ spec:
             secretName: {{ include "xnat-web.fullname" . }}
         {{- $context := . -}}
         {{- range $name, $c := .Values.volumes }}
+        {{- if $c.size }}
         - name: {{ $name }}
           persistentVolumeClaim:
             claimName: {{ $c.existingClaim | default (printf "%s-%s" (include "xnat-web.fullname" $context) $name) }}
+        {{- end }}
         {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/releases/xnat/charts/xnat-web/values.yaml
+++ b/releases/xnat/charts/xnat-web/values.yaml
@@ -210,7 +210,7 @@ dicom_scp:
       # loadBalancerIp: "130.95.27.91"
 
 postgresql:
-  postgresqlDatabase: "xnat"
-  postgresqlUsername: "xnat"
-  postgresqlPassword: "xnat"
+  postgresqlDatabase: "xnat_web"
+  postgresqlUsername: "xnat_web"
+  #postgresqlPassword: ""
 

--- a/releases/xnat/values.yaml
+++ b/releases/xnat/values.yaml
@@ -3,9 +3,9 @@
 # Declare variables to be passed into your templates.
 
 global:
-  postgresql:
-    postgresqlDatabase: "xnat"
-    postgresqlUsername: "xnat"
+  postgresql: {}
+    #postgresqlDatabase: ""
+    #postgresqlUsername: ""
     #postgresqlPassword: ""
     #servicePort: ""
 
@@ -13,6 +13,10 @@ global:
 # WARNING: Only change this post deployment if you know what you are doing
 postgresql:
   enabled: true
+  postgresqlDatabase: "xnat"
+  postgresqlPassword: "xnat"
+  postgresqlUsername: "xnat"
+
 # External Database service endpoint, ensure `postgresql.enabled: false`
 postgresqlExternalName: ""
 postgresqlExternalIPs: []
@@ -146,14 +150,16 @@ xnat-web:
     archive:
       #existingClaim: ""
       #storageClass: "-"
-      size: 1Ti
+      size: 1Gi
     prearchive:
       #existingClaim: ""
       #storageClass: "-"
-      size: 1Ti
+      size: 1Gi
 
   # xnat-web postgresql client setting overrides
   # these values can be set in the global section
   postgresql:
+    postgresqlDatabase: "xnat"
     postgresqlPassword: "xnat"
+    postgresqlUsername: "xnat"
 


### PR DESCRIPTION
add xnat-web dependency to fix lint test
add xnat-web dependency condition to disable xnat-web
xnat-web.volumes.*.size=false disables predefined volume setting
xnat-web.volumes.*.mountPropagation added to settings
fix global override problem with postgresql settings as these take presidence over local settings and should remain unset
xnat-web.volumes.*.size efault setting lowered to 1Gi from 1Ti for development and testing environments. This value should be set for production once evaluation is over.