### PR TITLE
Insure headless xnat service and ingressClassName in values.yaml

### DIFF
--- a/releases/xnat/Chart.yaml
+++ b/releases/xnat/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.5
+version: 1.1.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/releases/xnat/charts/xnat-web/Chart.yaml
+++ b/releases/xnat/charts/xnat-web/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.5
+version: 1.1.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/releases/xnat/charts/xnat-web/templates/ingress.yaml
+++ b/releases/xnat/charts/xnat-web/templates/ingress.yaml
@@ -13,6 +13,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
+  {{- end }}
   {{- if .Values.ingress.tls }}
   tls:
     {{- range .Values.ingress.tls }}
@@ -31,7 +34,7 @@ spec:
           - path: "/"
             pathType: Prefix
             backend:
-              serviceName: {{ $fullName }}-headless
+              serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}
     {{- end }}
 {{- else if semverCompare ">=1.22-0" .Capabilities.KubeVersion.GitVersion -}}
@@ -46,6 +49,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
+  {{- end }}
   {{- if .Values.ingress.tls }}
   tls:
     {{- range .Values.ingress.tls }}
@@ -65,7 +71,7 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: {{ $fullName }}-headless
+                name: {{ $fullName }}
                 port: 
                   number: {{ $svcPort }}
     {{- end }}

--- a/releases/xnat/charts/xnat-web/templates/service.yaml
+++ b/releases/xnat/charts/xnat-web/templates/service.yaml
@@ -14,7 +14,6 @@ spec:
   selector:
     {{- include "xnat-web.selectorLabels" . | nindent 4 }}
   sessionAffinity: "ClientIP"
-{{ if (eq .Values.service.type "ClusterIP") }}
 ---
 apiVersion: v1
 kind: Service
@@ -23,7 +22,7 @@ metadata:
   labels:
     {{- include "xnat-web.labels" . | nindent 4 }}
 spec:
-  type: {{ .Values.service.type }}
+  type: ClusterIP
   clusterIP: None
   ports:
     - port: {{ .Values.service.port }}
@@ -33,7 +32,6 @@ spec:
   selector:
     {{- include "xnat-web.selectorLabels" . | nindent 4 }}
   sessionAffinity: "ClientIP"
-{{- end }}
 {{- if .Values.dicom_scp.recievers }}
 ---
 apiVersion: v1

--- a/releases/xnat/charts/xnat-web/values.yaml
+++ b/releases/xnat/charts/xnat-web/values.yaml
@@ -50,6 +50,7 @@ service:
 ingress:
   enabled: false
   annotations: {}
+  ingressClassName: ""
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
     # nginx.ingress.kubernetes.io/whitelist-source-range: "130.95.0.0/16"


### PR DESCRIPTION
This pull request:

- Changes the xnat-web headless service to be created regardless of the service type.

- A second service is created and assigned the type via .Values.service.type and the ingress is configured to use this service

- Add a ingressClassName parameter to values.yaml