### PR TITLE
use postgres service fqdn

### DIFF
--- a/releases/xnat/charts/xnat-web/templates/secret.yaml
+++ b/releases/xnat/charts/xnat-web/templates/secret.yaml
@@ -16,7 +16,7 @@ stringData:
     # Released under the Simplified BSD.
     #
     datasource.driver=org.postgresql.Driver
-    datasource.url=jdbc:postgresql://{{ template "xnat-web.postgresql.fullname" . }}/{{ template "xnat-web.postgresql.postgresqlDatabase" . }}
+    datasource.url=jdbc:postgresql://{{ template "xnat-web.postgresql.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local/{{ template "xnat-web.postgresql.postgresqlDatabase" . }}
     datasource.username={{ template "xnat-web.postgresql.postgresqlUsername" . }}
     datasource.password={{ template "xnat-web.postgresql.postgresqlPassword" . }}
     hibernate.dialect=org.hibernate.dialect.PostgreSQL9Dialect


### PR DESCRIPTION
I think this is related to #107 he seems to have run into the same issue as me, but I think he didn't quite get what the external name was doing. I think it's an RKE2 thing, but I cannot reach a service in my cluster with just the service name, I need the namespaced service domain name like so: 
`{{service}}.{{namespace}}.svc(.cluster.local)`
This commit simply changes xnat's postgres configuration to use the fqdn of the external name service: 
`{{service}}.{{namespace}}.svc.cluster.local`
Should be completely compatible with existing deployments.
Thanks!