### PR TITLE
Populate XNAT NOTES.txt with practical access instructions

### DIFF
--- a/releases/xnat/templates/NOTES.txt
+++ b/releases/xnat/templates/NOTES.txt
@@ -1,0 +1,30 @@
+{{- if .Values.ingress.enabled }}
+1. XNAT URL:
+{{- range $h := .Values.ingress.hosts }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $h.host }}
+{{- end }}
+{{- else }}
+1. Get the XNAT URL by running these commands:
+{{- if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "xnat.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+  kubectl get svc --namespace {{ .Release.Namespace }} {{ include "xnat.fullname" . }} -w
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "xnat.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "xnat.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+  echo "Visit http://127.0.0.1:8080"
+{{- end }}
+{{- end }}
+
+{{- if .Values.dicom_scp.recievers }}
+2. DICOM SCP receiver configuration:
+{{- range $r := .Values.dicom_scp.recievers }}
+  - AE_TITLE={{ $r.ae_title }} PORT={{ $r.port }}
+{{- end }}
+{{- end }}


### PR DESCRIPTION
## Summary
Improves post-install operator guidance by adding concrete output to XNAT Helm `NOTES.txt`.

## Changes
- Added XNAT URL guidance when ingress is enabled
- Added service-type fallback commands for NodePort / LoadBalancer / ClusterIP
- Added DICOM SCP receiver summary from configured values

## Why
Issue #3 requests useful content in XNAT NOTES. This improves immediate usability after install/upgrade without changing runtime behavior.

## Related issue
- Closes #3
