### PR TITLE
Fix chart releaser failure by defining xnat-web dependency repository

### DIFF
--- a/releases/xnat/Chart.yaml
+++ b/releases/xnat/Chart.yaml
@@ -29,4 +29,5 @@ dependencies:
   version: "15.5.38"  # postgresql app version 16.4.0
 - name: xnat-web
   condition: xnat-web.enabled
+  repository: "https://australian-imaging-service.github.io/charts"
   version: "1.1.23"


### PR DESCRIPTION
## Summary
Fixes release pipeline packaging failure caused by missing repository metadata in xnat chart dependencies.

## Problem
Issue #102 reports chart-releaser failing with:

`Error: could not find protocol handler for:`

This points to an empty dependency repository URL during chart packaging.

## Change
In `releases/xnat/Chart.yaml`, add explicit repository for dependency `xnat-web`:

- `repository: https://australian-imaging-service.github.io/charts`

## Impact
Dependency metadata fix only; no template runtime behavior changes.

## Related issue
- Closes #102
