### PR TITLE
Fix AAF support email typo in integration docs

### DIFF
--- a/docs/Operations/AAF-Integration.md
+++ b/docs/Operations/AAF-Integration.md
@@ -8,7 +8,7 @@ weight: 10
 
 AAF have several services they offer which authenticate users, for example, Rapid Connect.
 We are interested in the AAF OIDC RP service.
-Please contact AAF Support via email at support@aaf.net.au to apply for a ClientId and Secret.
+Please contact AAF Support via email at support@aaf.edu.au to apply for a ClientId and Secret.
 
 They will ask you these questions:
 


### PR DESCRIPTION
## Summary
Corrects a typo in AAF integration documentation where the support contact email domain was incorrect.

## Change
- `docs/Operations/AAF-Integration.md`
  - `support@aaf.net.au` -> `support@aaf.edu.au`

## Related issue
- Closes #125
