### PR TITLE
Remove default XNAT resource requests/limits to avoid invalid override combinations

### DIFF
--- a/releases/xnat/charts/xnat-web/values.yaml
+++ b/releases/xnat/charts/xnat-web/values.yaml
@@ -71,17 +71,16 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
-resources:
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'
-  requests:
-    cpu: 250m
-    memory: 4000Mi
-  limits:
-    cpu: 250m
-    memory: 4000Mi
+resources: {}
+  # We intentionally keep resources empty by default.
+  # Configure requests/limits per deployment environment.
+  # Example:
+  # requests:
+  #   cpu: 250m
+  #   memory: 4000Mi
+  # limits:
+  #   cpu: 250m
+  #   memory: 4000Mi
 
 # nonheapmem can be manually set here. It's recommended to be set at 40-50% of the request/limit memory for XNAT
 # When it's empty, it uses the default configuration in XNAT image

--- a/releases/xnat/values.yaml
+++ b/releases/xnat/values.yaml
@@ -98,17 +98,16 @@ xnat-web:
     #    hosts:
     #      - chart-example.local
 
-  resources:
-    # We usually recommend not to specify default resources and to leave this as a conscious
-    # choice for the user. This also increases chances charts run on environments with little
-    # resources, such as Minikube. If you do want to specify resources, uncomment the following
-    # lines, adjust them as necessary, and remove the curly braces after 'resources:'
-    requests:
-      cpu: 250m
-      memory: 4000Mi
-    limits:
-      cpu: 250m
-      memory: 4000Mi
+  resources: {}
+    # We intentionally keep resources empty by default.
+    # Configure requests/limits per deployment environment.
+    # Example:
+    # requests:
+    #   cpu: 250m
+    #   memory: 4000Mi
+    # limits:
+    #   cpu: 250m
+    #   memory: 4000Mi
 
   # nonheapmem can be manually set here. It's recommended to be set at 40-50% of the request/limit memory for XNAT
   # When it's empty, it uses the default configuration in XNAT image


### PR DESCRIPTION
## Summary
Resolves deployment failures caused by conflicting default resource requests/limits in XNAT chart values.

## Problem
Issue #139 reports invalid pod specs when users override only part of resources (for example request CPU > default limit CPU).

## Change
- Set default resources to empty `{}` in:
  - `releases/xnat/values.yaml` (`xnat-web.resources`)
  - `releases/xnat/charts/xnat-web/values.yaml`
- Kept commented examples for operator guidance

## Why
Helm best practice is to avoid opinionated hard defaults that conflict with partial environment overrides.

## Related issue
- Closes #139
