### PR TITLE
Add documented PostgreSQL tuning override pattern for XNAT deployments

### DIFF
--- a/releases/xnat/README.md
+++ b/releases/xnat/README.md
@@ -67,3 +67,28 @@ The following tables list the configuration parameters of the XNAT Chart and the
 | For more *xnat-web* detail and configuration options please visit the [xnat-web](https://github.com/Australian-Imaging-Service/charts/tree/main/charts/xnat-web#Parameters) sub-chart |||
 
 
+
+### PostgreSQL memory tuning
+
+If you use the bundled Bitnami PostgreSQL sub-chart, you can provide tuning values through:
+
+- `postgresql.primary.resources`
+- `postgresql.primary.extendedConfiguration`
+
+Example override snippet:
+
+```yaml
+postgresql:
+  primary:
+    resources:
+      requests:
+        cpu: 500m
+        memory: 512Mi
+      limits:
+        cpu: 1000m
+        memory: 1024Mi
+    extendedConfiguration: |
+      work_mem = 50MB
+      maintenance_work_mem = 128MB
+      effective_cache_size = 256MB
+```

--- a/releases/xnat/values.yaml
+++ b/releases/xnat/values.yaml
@@ -25,6 +25,11 @@ postgresql:
       limits:
         cpu: 1000m
         memory: 1024Mi
+    # Optional PostgreSQL tuning overrides (example)
+    # extendedConfiguration: |
+    #   work_mem = 50MB
+    #   maintenance_work_mem = 128MB
+    #   effective_cache_size = 256MB
   image:
     repository: bitnamilegacy/postgresql
     tag: 16.4.0-debian-12-r28      


### PR DESCRIPTION
## Summary
Adds clear PostgreSQL tuning guidance and values structure for bundled DB deployments.

## Context
Issue #69 requests support/guidance for memory tuning values such as:
- `work_mem`
- `maintenance_work_mem`
- `effective_cache_size`

## Changes
- `releases/xnat/values.yaml`
  - Added commented `postgresql.primary.extendedConfiguration` example block
- `releases/xnat/README.md`
  - Added "PostgreSQL memory tuning" section with copy/paste override snippet

## Impact
Non-breaking documentation/config guidance enhancement.

## Related issue
- Closes #69
