### PR TITLE
Document xnat-web sub-chart value discovery and override workflow

### DIFF
--- a/releases/xnat/README.md
+++ b/releases/xnat/README.md
@@ -67,3 +67,28 @@ The following tables list the configuration parameters of the XNAT Chart and the
 | For more *xnat-web* detail and configuration options please visit the [xnat-web](https://github.com/Australian-Imaging-Service/charts/tree/main/charts/xnat-web#Parameters) sub-chart |||
 
 
+
+### Viewing and overriding sub-chart values (`xnat-web`)
+
+`helm show values ais/xnat` shows the parent chart values. The embedded sub-chart (`xnat-web`) values are overridden under the `xnat-web:` key in the parent values file.
+
+To inspect the sub-chart defaults directly in this repository:
+
+```bash
+cat releases/xnat/charts/xnat-web/values.yaml
+```
+
+To override sub-chart values in your deployment file:
+
+```yaml
+xnat-web:
+  resources: {}
+  ingress:
+    enabled: true
+```
+
+Then install/upgrade as usual:
+
+```bash
+helm upgrade --install my-xnat ais/xnat -f my-values.yaml
+```


### PR DESCRIPTION
## Summary
Adds practical guidance for viewing and overriding `xnat-web` sub-chart values from the parent `xnat` chart workflow.

## Problem
Issue #70 reports confusion where `helm show values ais/xnat` does not clearly expose sub-chart defaults as expected.

## Change
In `releases/xnat/README.md`, added a section explaining:
- where to inspect embedded `xnat-web` default values in repo
- how to override sub-chart values using `xnat-web:` in parent values file
- deployment command with overrides

## Impact
Documentation-only improvement; no chart behavior change.

## Related issue
- Closes #70
