### PR TITLE
Support existingClaim-only XNAT volume entries in statefulset rendering

### DIFF
--- a/releases/xnat/charts/xnat-web/templates/statefulset.yaml
+++ b/releases/xnat/charts/xnat-web/templates/statefulset.yaml
@@ -90,7 +90,7 @@ spec:
             {{- end }}
             {{- end }}
             {{- range $name, $c := .Values.volumes }}
-            {{- if $c.size }}
+            {{- if or $c.size $c.existingClaim }}
             - mountPath: {{ $c.mountPath | quote }}
               name: {{ $name | quote }}
               {{- if $c.mountPropagation }}
@@ -167,7 +167,7 @@ spec:
             secretName: {{ include "xnat-web.fullname" . }}
         {{- $context := . -}}
         {{- range $name, $c := .Values.volumes }}
-        {{- if $c.size }}
+        {{- if or $c.size $c.existingClaim }}
         - name: {{ $name }}
           persistentVolumeClaim:
             claimName: {{ $c.existingClaim | default (printf "%s-%s" (include "xnat-web.fullname" $context) $name) }}


### PR DESCRIPTION
## Summary
Improves XNAT volume configurability by supporting `existingClaim`-only volume entries.

## Problem
Current template logic requires `size` to include `.Values.volumes` mounts and volume refs. This prevents valid use of pre-provisioned PVCs where only `existingClaim` should be needed.

## Change
In `releases/xnat/charts/xnat-web/templates/statefulset.yaml`:
- Updated conditions from `if $c.size` to `if or $c.size $c.existingClaim` for:
  1) volumeMount entries
  2) pod volume entries

## Impact
Backward-compatible enhancement; existing size-based configs still work, and existingClaim-only configs now render correctly.

## Related issue
- Closes #172
