### PR TITLE
Support persistence existingClaim mounts in xnat-web statefulset

### DIFF
--- a/releases/xnat/charts/xnat-web/templates/statefulset.yaml
+++ b/releases/xnat/charts/xnat-web/templates/statefulset.yaml
@@ -84,13 +84,13 @@ spec:
             {{- end }}
             {{- end }}
             {{- range $name, $c := .Values.persistence }}
-            {{- if $c.size }}
+            {{- if or $c.size $c.existingClaim }}
             - mountPath: {{ $c.mountPath | quote }}
               name: {{ $name | quote }}
             {{- end }}
             {{- end }}
             {{- range $name, $c := .Values.volumes }}
-            {{- if $c.size }}
+            {{- if or $c.size $c.existingClaim }}
             - mountPath: {{ $c.mountPath | quote }}
               name: {{ $name | quote }}
               {{- if $c.mountPropagation }}
@@ -166,8 +166,15 @@ spec:
           secret:
             secretName: {{ include "xnat-web.fullname" . }}
         {{- $context := . -}}
+        {{- range $name, $c := .Values.persistence }}
+        {{- if $c.existingClaim }}
+        - name: {{ $name }}
+          persistentVolumeClaim:
+            claimName: {{ $c.existingClaim }}
+        {{- end }}
+        {{- end }}
         {{- range $name, $c := .Values.volumes }}
-        {{- if $c.size }}
+        {{- if or $c.size $c.existingClaim }}
         - name: {{ $name }}
           persistentVolumeClaim:
             claimName: {{ $c.existingClaim | default (printf "%s-%s" (include "xnat-web.fullname" $context) $name) }}


### PR DESCRIPTION
## Summary
Adds support for persistence entries that specify `existingClaim` without requiring `size`.

## Problem
Issue #132 highlights persistent storage behavior. Current xnat-web template mounts `.Values.persistence` only when `size` is set, so `existingClaim`-only persistence entries are skipped.

## Changes
In `releases/xnat/charts/xnat-web/templates/statefulset.yaml`:
- persistence mount condition changed to `or $c.size $c.existingClaim`
- added pod volume entries for persistence items with `existingClaim`
- retained existing dynamic claim template behavior for `!existingClaim && size`

## Impact
Backward compatible improvement enabling pre-provisioned PVC usage for persistence paths.

## Related issue
- Closes #132
