### PR TITLE
fix: remove default xnat-web CPU/memory limits

### DIFF
--- a/releases/xnat/charts/xnat-web/values.yaml
+++ b/releases/xnat/charts/xnat-web/values.yaml
@@ -71,17 +71,16 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
-resources:
+resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'
-  requests:
-    cpu: 250m
-    memory: 4000Mi
-  limits:
-    cpu: 250m
-    memory: 4000Mi
+  # resources, such as Minikube. If you do want to specify resources, replace `{}` with:
+  # requests:
+  #   cpu: 250m
+  #   memory: 4000Mi
+  # limits:
+  #   cpu: 250m
+  #   memory: 4000Mi
 
 # nonheapmem can be manually set here. It's recommended to be set at 40-50% of the request/limit memory for XNAT
 # When it's empty, it uses the default configuration in XNAT image

--- a/releases/xnat/values.yaml
+++ b/releases/xnat/values.yaml
@@ -98,17 +98,16 @@ xnat-web:
     #    hosts:
     #      - chart-example.local
 
-  resources:
+  resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious
     # choice for the user. This also increases chances charts run on environments with little
-    # resources, such as Minikube. If you do want to specify resources, uncomment the following
-    # lines, adjust them as necessary, and remove the curly braces after 'resources:'
-    requests:
-      cpu: 250m
-      memory: 4000Mi
-    limits:
-      cpu: 250m
-      memory: 4000Mi
+    # resources, such as Minikube. If you do want to specify resources, replace `{}` with:
+    # requests:
+    #   cpu: 250m
+    #   memory: 4000Mi
+    # limits:
+    #   cpu: 250m
+    #   memory: 4000Mi
 
   # nonheapmem can be manually set here. It's recommended to be set at 40-50% of the request/limit memory for XNAT
   # When it's empty, it uses the default configuration in XNAT image


### PR DESCRIPTION
## Summary
Remove default CPU/memory requests+limits from xnat-web values so chart users can set resources intentionally without inheriting hard limits.

## Changes
- Set  default to  in umbrella chart values
- Set  default to  in  subchart values
- Kept prior resource examples as commented guidance

## Why
Issue #139 reports deployments failing when requests are raised but default CPU limit (250m) remains, causing invalid  combinations.

Fixes #139