### PR TITLE
feat: support secret-backed plugin config in xnat-web

### DIFF
--- a/releases/xnat/charts/xnat-web/templates/secret.yaml
+++ b/releases/xnat/charts/xnat-web/templates/secret.yaml
@@ -38,7 +38,10 @@ type: Opaque
 stringData:
 {{- range $p }}
   {{ .provider.id }}-provider.properties: |
-  {{- include "xnat-web.envify" (list "" .) | nindent 4 }}
+  {{- include "xnat-web.envify" (list "" (omit . "secretRefs")) | nindent 4 }}
+  {{- range .secretRefs }}
+    {{ .property }}={{- $secret := lookup "v1" "Secret" $.Release.Namespace .secretName }}{{- if and $secret (hasKey $secret.data .secretKey) }}{{ index $secret.data .secretKey | b64dec }}{{- else }}{{ default "" .default }}{{- end }}
+  {{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/releases/xnat/charts/xnat-web/values.yaml
+++ b/releases/xnat/charts/xnat-web/values.yaml
@@ -168,6 +168,13 @@ plugins: {}
   #      clientId: ""
   #      clientSecret: ""
   #      scopes: "openid,profile,email"
+  #      # Optional secretRefs allow sensitive values to be sourced from existing
+  #      # Kubernetes Secrets and merged into provider properties at render time.
+  #      # secretRefs:
+  #      #   - property: "openid.aaf.clientSecret"
+  #      #     secretName: "xnat-openid-secrets"
+  #      #     secretKey: "aafClientSecret"
+  #      #     # default: "" # optional fallback if secret/key is missing
   #      link: '<p>To sign-in using your AAF credentials, please click on the button below.</p><p><a href="/openid-login?providerId=aaf"><img src="/images/aaf_service_223x54.png" /></a></p>'
   #      # Flag that sets if we should be checking email domains
   #      # Domains below are the only ones allowed to login, empty array allows ALL domains


### PR DESCRIPTION
## Summary
Add optional  support for XNAT plugin provider configuration so sensitive values can be sourced from existing Kubernetes Secrets.

## What changed
- Added support for  entries under each plugin provider item in 
- Updated template rendering to:
  - keep existing config behavior unchanged
  - omit  from normal flattened properties output
  - append properties resolved from Kubernetes Secret keys via Helm 
- Added commented example in values docs for OpenID provider usage

## Backward compatibility
- Existing plugin configurations continue to render the same when  is not set.
- New behavior is opt-in.

## Example


Fixes #169