### PR TITLE
feat: add Gateway API support for xnat-web

### DIFF
--- a/releases/xnat/Chart.yaml
+++ b/releases/xnat/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.23
+version: 1.1.24
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -29,4 +29,4 @@ dependencies:
   version: "15.5.38"  # postgresql app version 16.4.0
 - name: xnat-web
   condition: xnat-web.enabled
-  version: "1.1.23"
+  version: "1.1.24"

--- a/releases/xnat/charts/xnat-web/Chart.yaml
+++ b/releases/xnat/charts/xnat-web/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.23
+version: 1.1.24
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/releases/xnat/charts/xnat-web/README.md
+++ b/releases/xnat/charts/xnat-web/README.md
@@ -20,3 +20,7 @@ The following tables list the configuration parameters of the XNAT-web Chart and
 | `dicom_scp.recievers.ae_title`              |                                                                                      | `XNAT` |
 | `dicom_scp.recievers.port`                  |                                                                                      | `8104` |
 | `dicom_scp.recievers.nodePort`              |                                                                                      | `nil` |
+| `gateway.enabled`                            | Enable Gateway API resources (`Gateway` + `HTTPRoute`)                              | `false` |
+| `gateway.existingGatewayName`                | Use an existing Gateway instead of creating one                                      | `""` |
+| `gateway.gatewayClassName`                   | GatewayClass used when chart creates a Gateway                                       | `nil` |
+| `gateway.hostnames`                          | Hostnames for generated HTTPRoute (falls back to `ingress.hosts`)                   | `[]` |

--- a/releases/xnat/charts/xnat-web/templates/gateway.yaml
+++ b/releases/xnat/charts/xnat-web/templates/gateway.yaml
@@ -1,0 +1,61 @@
+{{- if and .Values.gateway.enabled .Values.gateway.httpRoute.enabled -}}
+{{- $fullName := include "xnat-web.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- $parentName := .Values.gateway.existingGatewayName | default $fullName -}}
+{{- $hostnames := .Values.gateway.hostnames -}}
+{{- if and (not $hostnames) .Values.ingress.hosts -}}
+{{- $hostnames = pluck "host" .Values.ingress.hosts -}}
+{{- end -}}
+{{- if not .Values.gateway.existingGatewayName }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "xnat-web.labels" . | nindent 4 }}
+  {{- with .Values.gateway.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  gatewayClassName: {{ required "gateway.gatewayClassName is required when gateway.enabled=true and existingGatewayName is not set" .Values.gateway.gatewayClassName }}
+  listeners:
+    - name: {{ .Values.gateway.listener.name | default "http" }}
+      port: {{ .Values.gateway.listener.port | default 80 }}
+      protocol: {{ .Values.gateway.listener.protocol | default "HTTP" }}
+      {{- if $hostnames }}
+      hostname: {{ index $hostnames 0 | quote }}
+      {{- end }}
+      {{- with .Values.gateway.listener.allowedRoutes }}
+      allowedRoutes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+---
+{{- end }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "xnat-web.labels" . | nindent 4 }}
+spec:
+  parentRefs:
+    - name: {{ $parentName }}
+      {{- if .Values.gateway.httpRoute.parentSectionName }}
+      sectionName: {{ .Values.gateway.httpRoute.parentSectionName }}
+      {{- end }}
+  {{- if $hostnames }}
+  hostnames:
+    {{- range $hostnames }}
+    - {{ . | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ $fullName }}-headless
+          port: {{ $svcPort }}
+{{- end }}

--- a/releases/xnat/charts/xnat-web/values.yaml
+++ b/releases/xnat/charts/xnat-web/values.yaml
@@ -71,6 +71,25 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
+gateway:
+  enabled: false
+  # gatewayClassName: istio
+  # Existing Gateway to attach HTTPRoute to. If empty, chart creates a Gateway.
+  existingGatewayName: ""
+  annotations: {}
+  hostnames: []
+  #  - "chart-example.local"
+  listener:
+    name: http
+    port: 80
+    protocol: HTTP
+    allowedRoutes:
+      namespaces:
+        from: Same
+  httpRoute:
+    enabled: true
+    parentSectionName: ""
+
 resources:
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little

--- a/releases/xnat/values.yaml
+++ b/releases/xnat/values.yaml
@@ -98,6 +98,25 @@ xnat-web:
     #    hosts:
     #      - chart-example.local
 
+  gateway:
+    enabled: false
+    # gatewayClassName: istio
+    # Existing Gateway to attach HTTPRoute to. If empty, chart creates a Gateway.
+    existingGatewayName: ""
+    annotations: {}
+    hostnames: []
+    #  - "chart-example.local"
+    listener:
+      name: http
+      port: 80
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: Same
+    httpRoute:
+      enabled: true
+      parentSectionName: ""
+
   resources:
     # We usually recommend not to specify default resources and to leave this as a conscious
     # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
## Summary
Add Gateway API support to xnat-web chart by introducing optional Gateway and HTTPRoute resources as an Ingress alternative.

## Changes
- Added new template: releases/xnat/charts/xnat-web/templates/gateway.yaml
- Added values for gateway configuration in both xnat-web values and umbrella xnat values:
  - gateway.enabled
  - gateway.existingGatewayName
  - gateway.annotations
  - gateway.hostnames
  - gateway.listener.*
  - gateway.httpRoute.*
- Added fallback behavior for hostnames: if gateway.hostnames is empty, use ingress.hosts host entries.
- Updated xnat-web README with gateway parameters.
- Bumped chart versions to 1.1.24 (xnat and xnat-web dependency).

## Behavior
- If gateway.enabled=false: no Gateway API resources are created (existing behavior preserved).
- If gateway.enabled=true and existingGatewayName is empty: chart creates a Gateway and an HTTPRoute.
- If gateway.enabled=true and existingGatewayName is set: chart only creates HTTPRoute attached to that existing Gateway.

Fixes #176