### PR TITLE
feat: support existing secret for XNAT database password

### DIFF
--- a/releases/xnat/Chart.yaml
+++ b/releases/xnat/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.23
+version: 1.1.24
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -29,4 +29,4 @@ dependencies:
   version: "15.5.38"  # postgresql app version 16.4.0
 - name: xnat-web
   condition: xnat-web.enabled
-  version: "1.1.23"
+  version: "1.1.24"

--- a/releases/xnat/charts/xnat-web/Chart.yaml
+++ b/releases/xnat/charts/xnat-web/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.23
+version: 1.1.24
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/releases/xnat/charts/xnat-web/README.md
+++ b/releases/xnat/charts/xnat-web/README.md
@@ -11,6 +11,8 @@ The following tables list the configuration parameters of the XNAT-web Chart and
 | `global.postgresql.postgresqlDatabase`      | PostgreSQL database (overrides `postgresql.postgresqlDatabase`)                      | `nil` |
 | `global.postgresql.postgresqlUsername`      | PostgreSQL username (overrides `postgresql.postgresqlUsername`)                      | `nil` |
 | `global.postgresql.postgresqlPassword`      | PostgreSQL admin password (overrides `postgresql.postgresqlPassword`)                | `nil` |
+| `postgresql.existingSecret.name`            | Existing secret name for database password lookup                                     | `nil` |
+| `postgresql.existingSecret.key`             | Existing secret key containing database password                                      | `nil` |
 | `global.postgresql.servicePort`             | PostgreSQL port (overrides `postgresql.service.port`)                                | `nil` |
 | For more PostgreSQL detail and configuration options please visit the official [Bitnami Chart repository](https://github.com/bitnami/charts/tree/master/bitnami/postgresql). |||
 | `global.storageClass`                       | Global storage class for dynamic provisioning                                        | `nil` |

--- a/releases/xnat/charts/xnat-web/templates/_postgresql.tpl
+++ b/releases/xnat/charts/xnat-web/templates/_postgresql.tpl
@@ -22,8 +22,17 @@ Create the name of the PostgreSQL service account to use
 {{- end -}}
 
 {{- define "xnat-web.postgresql.postgresqlPassword" -}}
-{{- if .Values.global.postgresql.postgresqlPassword }}
+{{- if and .Values.postgresql.existingSecret .Values.postgresql.existingSecret.name .Values.postgresql.existingSecret.key }}
+{{- $s := lookup "v1" "Secret" .Release.Namespace .Values.postgresql.existingSecret.name }}
+{{- if and $s (hasKey $s.data .Values.postgresql.existingSecret.key) }}
+{{- index $s.data .Values.postgresql.existingSecret.key | b64dec }}
+{{- else }}
+{{- .Values.postgresql.postgresqlPassword }}
+{{- end }}
+{{- else if .Values.global.postgresql.postgresqlPassword }}
 {{- .Values.global.postgresql.postgresqlPassword }}
+{{- else if and .Values.global.postgresql.auth .Values.global.postgresql.auth.password }}
+{{- .Values.global.postgresql.auth.password }}
 {{- else }}
 {{- .Values.postgresql.postgresqlPassword }}
 {{- end }}

--- a/releases/xnat/charts/xnat-web/values.yaml
+++ b/releases/xnat/charts/xnat-web/values.yaml
@@ -14,6 +14,9 @@ postgresql: {}
   # postgresqlDatabase: "xnat_web"
   # postgresqlUsername: "xnat_web"
   # postgresqlPassword: "xnat_web"
+  # existingSecret:
+  #   name: "xnat-db-credentials"
+  #   key: "password"
 
 replicaCount: 1
 

--- a/releases/xnat/values.yaml
+++ b/releases/xnat/values.yaml
@@ -40,6 +40,9 @@ xnat-web:
     postgresqlDatabase: "xnat_web"
     postgresqlPassword: "xnat_web"
     postgresqlUsername: "xnat_web"
+    # existingSecret:
+    #   name: "xnat-db-credentials"
+    #   key: "password"
 
   enabled: true
   replicaCount: 1


### PR DESCRIPTION
## Summary
Add support for sourcing XNAT database password from an existing Kubernetes Secret in Helm templates.

## What changed
- Added optional values:
  - `postgresql.existingSecret.name`
  - `postgresql.existingSecret.key`
- Updated PostgreSQL password helper to resolve password in this order:
  1. existing secret key via `lookup`
  2. `global.postgresql.postgresqlPassword`
  3. `global.postgresql.auth.password`
  4. `postgresql.postgresqlPassword`
- Added commented examples in both xnat-web and umbrella xnat values.
- Updated xnat-web README parameter table.
- Bumped chart versions (`xnat-web` and `xnat`) to 1.1.24.

## Backward compatibility
- Existing deployments keep current behavior when `postgresql.existingSecret` is not set.
- Secret-based password is opt-in.

This addresses the database secret management aspect in issue #145.

Fixes #145