### PR TITLE
feat: wire xnat volume mount paths into initial setup config

### DIFF
--- a/releases/xnat/Chart.yaml
+++ b/releases/xnat/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.23
+version: 1.1.24
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -29,4 +29,4 @@ dependencies:
   version: "15.5.38"  # postgresql app version 16.4.0
 - name: xnat-web
   condition: xnat-web.enabled
-  version: "1.1.23"
+  version: "1.1.24"

--- a/releases/xnat/charts/xnat-web/Chart.yaml
+++ b/releases/xnat/charts/xnat-web/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.23
+version: 1.1.24
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/releases/xnat/charts/xnat-web/README.md
+++ b/releases/xnat/charts/xnat-web/README.md
@@ -15,7 +15,10 @@ The following tables list the configuration parameters of the XNAT-web Chart and
 | For more PostgreSQL detail and configuration options please visit the official [Bitnami Chart repository](https://github.com/bitnami/charts/tree/master/bitnami/postgresql). |||
 | `global.storageClass`                       | Global storage class for dynamic provisioning                                        | `nil` |
 | `volumes.archive.existingClaim`    | | |
+| `volumes.archive.mountPath`        | Archive path propagated to XNAT setup (`archivePath`)                                | `/data/xnat/archive` |
 | `volumes.prearchive.existingClaim` | | |
+| `volumes.prearchive.mountPath`     | Prearchive path propagated to XNAT setup (`prearchivePath`)                          | `/data/xnat/prearchive` |
+| `persistence.cache.mountPath`      | Cache path propagated to XNAT setup (`cachePath`)                                    | `/data/xnat/cache` |
 | `dicom_scp.serviceType                      | DICOM C-STORE Service Class Provider (SCP) service type (NodePort|LoadBalancer)      | `NodePort` |
 | `dicom_scp.recievers.ae_title`              |                                                                                      | `XNAT` |
 | `dicom_scp.recievers.port`                  |                                                                                      | `8104` |

--- a/releases/xnat/charts/xnat-web/templates/secret.yaml
+++ b/releases/xnat/charts/xnat-web/templates/secret.yaml
@@ -24,6 +24,9 @@ stringData:
     hibernate.show_sql=false
     hibernate.cache.use_second_level_cache=true
     hibernate.cache.use_query_cache=true
+    archivePath={{ .Values.volumes.archive.mountPath | default "/data/xnat/archive" }}
+    prearchivePath={{ .Values.volumes.prearchive.mountPath | default "/data/xnat/prearchive" }}
+    cachePath={{ .Values.persistence.cache.mountPath | default "/data/xnat/cache" }}
 
 {{- range $plugin, $p := .Values.plugins }}
 {{- if $p }}


### PR DESCRIPTION
## Summary
Implement configurable XNAT storage structure propagation so Helm values for archive/prearchive/cache mount paths are presented to XNAT initial setup config.

## Changes
- Updated `xnat-conf.properties` template generation to include:
  - `archivePath` from `volumes.archive.mountPath`
  - `prearchivePath` from `volumes.prearchive.mountPath`
  - `cachePath` from `persistence.cache.mountPath`
- Added README entries documenting mountPath-to-setup mapping.
- Bumped chart versions (`xnat-web` and umbrella `xnat`) to `1.1.24`.

## Why
Issue #172 requests better control of XNAT volume structure and ensuring configured paths are passed into initial setup for consistency.

## Backward compatibility
Defaults remain unchanged (`/data/xnat/archive`, `/data/xnat/prearchive`, `/data/xnat/cache`) when values are not overridden.

Fixes #172