### PR TITLE
feat: add opt-in fsGroup CSI ID mapping profile

### DIFF
--- a/releases/xnat/Chart.yaml
+++ b/releases/xnat/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.23
+version: 1.1.24
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -29,4 +29,4 @@ dependencies:
   version: "15.5.38"  # postgresql app version 16.4.0
 - name: xnat-web
   condition: xnat-web.enabled
-  version: "1.1.23"
+  version: "1.1.24"

--- a/releases/xnat/charts/xnat-web/Chart.yaml
+++ b/releases/xnat/charts/xnat-web/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.23
+version: 1.1.24
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/releases/xnat/charts/xnat-web/README.md
+++ b/releases/xnat/charts/xnat-web/README.md
@@ -14,6 +14,8 @@ The following tables list the configuration parameters of the XNAT-web Chart and
 | `global.postgresql.servicePort`             | PostgreSQL port (overrides `postgresql.service.port`)                                | `nil` |
 | For more PostgreSQL detail and configuration options please visit the official [Bitnami Chart repository](https://github.com/bitnami/charts/tree/master/bitnami/postgresql). |||
 | `global.storageClass`                       | Global storage class for dynamic provisioning                                        | `nil` |
+| `csiIdMapping.enabled`                      | Auto-apply `podSecurityContext.fsGroup` for CSI ID mapping                          | `false` |
+| `csiIdMapping.fsGroup`                      | fsGroup value used when `csiIdMapping.enabled=true` and fsGroup is not set manually | `2000` |
 | `volumes.archive.existingClaim`    | | |
 | `volumes.prearchive.existingClaim` | | |
 | `dicom_scp.serviceType                      | DICOM C-STORE Service Class Provider (SCP) service type (NodePort|LoadBalancer)      | `NodePort` |

--- a/releases/xnat/charts/xnat-web/templates/_deployment.yaml
+++ b/releases/xnat/charts/xnat-web/templates/_deployment.yaml
@@ -25,8 +25,12 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "xnat-web.serviceAccountName" . }}
+      {{- $podSecurityContext := deepCopy .Values.podSecurityContext }}
+      {{- if and .Values.csiIdMapping.enabled (not (hasKey $podSecurityContext "fsGroup")) }}
+      {{- $_ := set $podSecurityContext "fsGroup" (.Values.csiIdMapping.fsGroup | default 2000) }}
+      {{- end }}
       securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+        {{- toYaml $podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/releases/xnat/charts/xnat-web/templates/statefulset.yaml
+++ b/releases/xnat/charts/xnat-web/templates/statefulset.yaml
@@ -27,8 +27,12 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "xnat-web.serviceAccountName" . }}
+      {{- $podSecurityContext := deepCopy .Values.podSecurityContext }}
+      {{- if and .Values.csiIdMapping.enabled (not (hasKey $podSecurityContext "fsGroup")) }}
+      {{- $_ := set $podSecurityContext "fsGroup" (.Values.csiIdMapping.fsGroup | default 2000) }}
+      {{- end }}
       securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+        {{- toYaml $podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/releases/xnat/charts/xnat-web/values.yaml
+++ b/releases/xnat/charts/xnat-web/values.yaml
@@ -48,6 +48,11 @@ securityContext: {}
   # readOnlyRootFilesystem: true
   # runAsNonRoot: true
   # runAsUser: 1000
+  # runAsGroup: 2000
+
+csiIdMapping:
+  enabled: false
+  fsGroup: 2000
 
 service:
   port: 80

--- a/releases/xnat/values.yaml
+++ b/releases/xnat/values.yaml
@@ -75,6 +75,11 @@ xnat-web:
     # readOnlyRootFilesystem: true
     # runAsNonRoot: true
     # runAsUser: 1000
+    # runAsGroup: 2000
+
+  csiIdMapping:
+    enabled: false
+    fsGroup: 2000
 
   service:
     port: 80


### PR DESCRIPTION
## Summary
Add a safer, opt-in CSI ID mapping profile for pod security context to support fsGroup-based storage mapping scenarios.

## Changes
- Added new values:
  - `csiIdMapping.enabled` (default `false`)
  - `csiIdMapping.fsGroup` (default `2000`)
- Updated pod securityContext rendering in both deployment/statefulset templates:
  - when `csiIdMapping.enabled=true` and `podSecurityContext.fsGroup` is not set, automatically inject `fsGroup`.
  - if user already sets `podSecurityContext.fsGroup`, user value wins.
- Added `runAsGroup` comment examples in values.
- Updated xnat-web README parameter table.
- Bumped chart versions (`xnat-web` and umbrella `xnat`) to `1.1.24`.

## Why
Issue #163 requests exploration of pod security context for cvmfs/CSI ID mapping and specifically references `fsGroup: 2000`. This PR provides a controlled and backward-compatible way to enable that behavior.

Fixes #163