### PR TITLE
feat: add optional JMX exporter metrics support for xnat-web

### DIFF
--- a/releases/xnat/Chart.yaml
+++ b/releases/xnat/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.23
+version: 1.1.24
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -29,4 +29,4 @@ dependencies:
   version: "15.5.38"  # postgresql app version 16.4.0
 - name: xnat-web
   condition: xnat-web.enabled
-  version: "1.1.23"
+  version: "1.1.24"

--- a/releases/xnat/charts/xnat-web/Chart.yaml
+++ b/releases/xnat/charts/xnat-web/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.23
+version: 1.1.24
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/releases/xnat/charts/xnat-web/README.md
+++ b/releases/xnat/charts/xnat-web/README.md
@@ -14,6 +14,10 @@ The following tables list the configuration parameters of the XNAT-web Chart and
 | `global.postgresql.servicePort`             | PostgreSQL port (overrides `postgresql.service.port`)                                | `nil` |
 | For more PostgreSQL detail and configuration options please visit the official [Bitnami Chart repository](https://github.com/bitnami/charts/tree/master/bitnami/postgresql). |||
 | `global.storageClass`                       | Global storage class for dynamic provisioning                                        | `nil` |
+| `jmxExporter.enabled`                       | Enable Tomcat JMX Exporter javaagent configuration                                  | `false` |
+| `jmxExporter.port`                          | Metrics port exposed by JMX exporter                                                | `9404` |
+| `jmxExporter.javaAgentPath`                 | Path to JMX exporter javaagent jar in container                                     | `/opt/jmx-exporter/jmx_prometheus_javaagent.jar` |
+| `jmxExporter.configMountPath`               | Mount path of JMX exporter config in container                                      | `/etc/jmx-exporter/config.yaml` |
 | `volumes.archive.existingClaim`    | | |
 | `volumes.prearchive.existingClaim` | | |
 | `dicom_scp.serviceType                      | DICOM C-STORE Service Class Provider (SCP) service type (NodePort|LoadBalancer)      | `NodePort` |

--- a/releases/xnat/charts/xnat-web/templates/jmx-exporter-configmap.yaml
+++ b/releases/xnat/charts/xnat-web/templates/jmx-exporter-configmap.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.jmxExporter.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "xnat-web.fullname" . }}-jmx-exporter
+  labels:
+    {{- include "xnat-web.labels" . | nindent 4 }}
+data:
+  config.yaml: |
+{{ .Values.jmxExporter.config | indent 4 }}
+{{- end }}

--- a/releases/xnat/charts/xnat-web/templates/service.yaml
+++ b/releases/xnat/charts/xnat-web/templates/service.yaml
@@ -11,6 +11,12 @@ spec:
       targetPort: 8080
       protocol: TCP
       name: http
+    {{- if .Values.jmxExporter.enabled }}
+    - port: {{ .Values.jmxExporter.port }}
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
+    {{- end }}
   selector:
     {{- include "xnat-web.selectorLabels" . | nindent 4 }}
   sessionAffinity: "ClientIP"

--- a/releases/xnat/charts/xnat-web/templates/statefulset.yaml
+++ b/releases/xnat/charts/xnat-web/templates/statefulset.yaml
@@ -36,18 +36,29 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- $request := trimSuffix "Mi" .Values.resources.requests.memory }}
-          env:
+          {{- $nonheapOpts := "" }}
           {{- if .Values.nonheapmem }}
           {{- $nonheap := trimSuffix "Mi" .Values.nonheapmem }}
-            - name: CATALINA_OPTS
-              value: -Xms{{ sub $request $nonheap }}m -Xmx{{ sub $request $nonheap }}m -Dxnat.home=/data/xnat/home
+          {{- $nonheapOpts = printf "-Xms%sm -Xmx%sm " (sub $request $nonheap) (sub $request $nonheap) }}
           {{- end }}
+          {{- $jmxAgentOpts := "" }}
+          {{- if .Values.jmxExporter.enabled }}
+          {{- $jmxAgentOpts = printf "-javaagent:%s=%v:%s " .Values.jmxExporter.javaAgentPath .Values.jmxExporter.port .Values.jmxExporter.configMountPath }}
+          {{- end }}
+          env:
+            - name: CATALINA_OPTS
+              value: {{ printf "%s%s-Dxnat.home=/data/xnat/home" $nonheapOpts $jmxAgentOpts | quote }}
             - name: TZ
               value: {{ .Values.timezone }}
           ports:
             - name: http
               containerPort: 8080
               protocol: TCP
+            {{- if .Values.jmxExporter.enabled }}
+            - name: metrics
+              containerPort: {{ .Values.jmxExporter.port }}
+              protocol: TCP
+            {{- end }}
           livenessProbe:
             {{- toYaml .Values.probes.liveness | nindent 12 }}
           readinessProbe:
@@ -73,6 +84,12 @@ spec:
               mountPath: "/data/xnat/home/config/xnat-conf.properties"
               readOnly: true
               subPath: "xnat-conf.properties"
+            {{- if .Values.jmxExporter.enabled }}
+            - name: jmx-exporter-config
+              mountPath: {{ .Values.jmxExporter.configMountPath | quote }}
+              readOnly: true
+              subPath: config.yaml
+            {{- end }}
             {{- range $plugin, $p := .Values.plugins }}
             {{- range $p }}
             {{- if .auth }}
@@ -165,6 +182,11 @@ spec:
         - name: xnat-config
           secret:
             secretName: {{ include "xnat-web.fullname" . }}
+        {{- if .Values.jmxExporter.enabled }}
+        - name: jmx-exporter-config
+          configMap:
+            name: {{ include "xnat-web.fullname" . }}-jmx-exporter
+        {{- end }}
         {{- $context := . -}}
         {{- range $name, $c := .Values.volumes }}
         {{- if $c.size }}

--- a/releases/xnat/charts/xnat-web/values.yaml
+++ b/releases/xnat/charts/xnat-web/values.yaml
@@ -53,6 +53,17 @@ service:
   port: 80
   type: ClusterIP
 
+jmxExporter:
+  enabled: false
+  port: 9404
+  javaAgentPath: "/opt/jmx-exporter/jmx_prometheus_javaagent.jar"
+  configMountPath: "/etc/jmx-exporter/config.yaml"
+  config: |
+    lowercaseOutputName: true
+    lowercaseOutputLabelNames: true
+    rules:
+      - pattern: ".*"
+
 ingress:
   enabled: false
   annotations: {}

--- a/releases/xnat/values.yaml
+++ b/releases/xnat/values.yaml
@@ -80,6 +80,17 @@ xnat-web:
     port: 80
     type: ClusterIP
 
+  jmxExporter:
+    enabled: false
+    port: 9404
+    javaAgentPath: "/opt/jmx-exporter/jmx_prometheus_javaagent.jar"
+    configMountPath: "/etc/jmx-exporter/config.yaml"
+    config: |
+      lowercaseOutputName: true
+      lowercaseOutputLabelNames: true
+      rules:
+        - pattern: ".*"
+
   ingress:
     enabled: false
     annotations: {}


### PR DESCRIPTION
## Summary
Add optional Tomcat JMX Exporter support to the xnat-web Helm chart so JVM/application metrics can be exposed from the XNAT web pod.

## Changes
- Added new `jmxExporter` values in xnat-web and umbrella values:
  - `jmxExporter.enabled`
  - `jmxExporter.port`
  - `jmxExporter.javaAgentPath`
  - `jmxExporter.configMountPath`
  - `jmxExporter.config`
- Added `jmx-exporter-configmap.yaml` template to render exporter config.
- Updated StatefulSet template to:
  - inject `-javaagent:<path>=<port>:<config>` into `CATALINA_OPTS` when enabled
  - mount exporter config into the container
  - expose metrics container port
- Updated Service template to expose `metrics` port when enabled.
- Updated README parameter table.
- Bumped chart versions to `1.1.24`.

## Notes
- Feature is opt-in and backward compatible (`enabled=false` by default).
- Default javaagent path is configurable to match image-specific layouts.

Fixes #138