### PR TITLE
feat(xnat-web): ServiceAccount JWT for ActiveMQ client auth

### DIFF
--- a/releases/xnat/charts/xnat-web/README.md
+++ b/releases/xnat/charts/xnat-web/README.md
@@ -2,6 +2,22 @@
 
 ## Parameters
 
+## ActiveMQ (Issue #175)
+
+This chart can inject Spring ActiveMQ client configuration into the XNAT web pod.
+
+For Kubernetes ServiceAccount JWT authentication (OAuth/Bearer-style), set:
+
+- `activemq.enabled=true`
+- `activemq.auth.mode=serviceAccountJwt`
+
+The chart will mount a projected ServiceAccount token at `activemq.auth.serviceAccountJwt.tokenPath` and start Tomcat with `SPRING_ACTIVEMQ_PASSWORD` loaded from that file.
+
+Notes:
+- Kubernetes will automatically rotate the projected token file.
+- The application must reconnect/reload credentials to fully benefit from token rotation.
+
+
 The following tables list the configuration parameters of the XNAT-web Chart and their default values.
 
 | Parameter                                   | Description                                                                          | Default |

--- a/releases/xnat/charts/xnat-web/templates/secret.yaml
+++ b/releases/xnat/charts/xnat-web/templates/secret.yaml
@@ -25,6 +25,17 @@ stringData:
     hibernate.cache.use_second_level_cache=true
     hibernate.cache.use_query_cache=true
 
+    {{- if .Values.activemq.enabled }}
+    # ActiveMQ client settings (Issue #175)
+    # These are standard Spring Boot properties (may also be supplied via env vars).
+    spring.activemq.broker-url={{ .Values.activemq.brokerUrl }}
+    spring.activemq.user={{ default (include "xnat-web.serviceAccountName" .) .Values.activemq.user }}
+    {{- if eq (default "basic" .Values.activemq.auth.mode) "serviceAccountJwt" }}
+    # For serviceAccountJwt mode, the chart reads the token file at container start and exports SPRING_ACTIVEMQ_PASSWORD.
+    # This key is left unset here to avoid storing tokens in a Secret.
+    {{- end }}
+    {{- end }}
+
 {{- range $plugin, $p := .Values.plugins }}
 {{- if $p }}
 ---

--- a/releases/xnat/charts/xnat-web/templates/statefulset.yaml
+++ b/releases/xnat/charts/xnat-web/templates/statefulset.yaml
@@ -36,7 +36,33 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- $request := trimSuffix "Mi" .Values.resources.requests.memory }}
+          {{- if and .Values.activemq.enabled (eq (default "basic" .Values.activemq.auth.mode) "serviceAccountJwt") }}
+          # Start Tomcat with SPRING_ACTIVEMQ_PASSWORD loaded from the projected ServiceAccount token.
+          # This enables Kubernetes-managed token rotation at the filesystem layer.
+          # NOTE: The application must reconnect/reload credentials to fully benefit from token rotation.
+          command:
+            - /bin/bash
+            - -lc
+          args:
+            - |
+              set -euo pipefail
+              if [ -n "${SPRING_ACTIVEMQ_PASSWORD_TOKEN_FILE:-}" ] && [ -f "$SPRING_ACTIVEMQ_PASSWORD_TOKEN_FILE" ]; then
+                export SPRING_ACTIVEMQ_PASSWORD="$(cat "$SPRING_ACTIVEMQ_PASSWORD_TOKEN_FILE")"
+              fi
+              exec /usr/local/tomcat/bin/catalina.sh run
+          {{- end }}
           env:
+          {{- if .Values.activemq.enabled }}
+            - name: SPRING_ACTIVEMQ_BROKER_URL
+              value: {{ .Values.activemq.brokerUrl | quote }}
+            - name: SPRING_ACTIVEMQ_USER
+              value: {{ default (include "xnat-web.serviceAccountName" .) .Values.activemq.user | quote }}
+            {{- if eq (default "basic" .Values.activemq.auth.mode) "serviceAccountJwt" }}
+            # Note: env vars are static; the entrypoint reads the token file at container start.
+            - name: SPRING_ACTIVEMQ_PASSWORD_TOKEN_FILE
+              value: {{ .Values.activemq.auth.serviceAccountJwt.tokenPath | quote }}
+            {{- end }}
+          {{- end }}
           {{- if .Values.nonheapmem }}
           {{- $nonheap := trimSuffix "Mi" .Values.nonheapmem }}
             - name: CATALINA_OPTS
@@ -73,6 +99,11 @@ spec:
               mountPath: "/data/xnat/home/config/xnat-conf.properties"
               readOnly: true
               subPath: "xnat-conf.properties"
+            {{- if and .Values.activemq.enabled (eq (default "basic" .Values.activemq.auth.mode) "serviceAccountJwt") }}
+            - name: activemq-sa-token
+              mountPath: {{ dir .Values.activemq.auth.serviceAccountJwt.tokenPath | quote }}
+              readOnly: true
+            {{- end }}
             {{- range $plugin, $p := .Values.plugins }}
             {{- range $p }}
             {{- if .auth }}
@@ -165,6 +196,17 @@ spec:
         - name: xnat-config
           secret:
             secretName: {{ include "xnat-web.fullname" . }}
+        {{- if and .Values.activemq.enabled (eq (default "basic" .Values.activemq.auth.mode) "serviceAccountJwt") }}
+        - name: activemq-sa-token
+          projected:
+            sources:
+              - serviceAccountToken:
+                  path: {{ base .Values.activemq.auth.serviceAccountJwt.tokenPath | quote }}
+                  {{- if .Values.activemq.auth.serviceAccountJwt.audience }}
+                  audience: {{ .Values.activemq.auth.serviceAccountJwt.audience | quote }}
+                  {{- end }}
+                  expirationSeconds: {{ .Values.activemq.auth.serviceAccountJwt.expirationSeconds }}
+        {{- end }}
         {{- $context := . -}}
         {{- range $name, $c := .Values.volumes }}
         {{- if $c.size }}

--- a/releases/xnat/charts/xnat-web/values.yaml
+++ b/releases/xnat/charts/xnat-web/values.yaml
@@ -123,6 +123,24 @@ volumes:
 
 plugins: {}
   #container-service: []
+
+# ActiveMQ client configuration (Issue #175)
+# These settings inject Spring ActiveMQ connection parameters into the XNAT web pod.
+# If using `serviceAccountJwt` auth, the chart mounts a projected ServiceAccount token
+# and starts Tomcat with SPRING_ACTIVEMQ_PASSWORD read from that token file.
+activemq:
+  enabled: false
+  brokerUrl: ""
+  user: ""
+  auth:
+    mode: basic # basic|serviceAccountJwt
+    serviceAccountJwt:
+      # Path where the projected token will be mounted inside the pod.
+      tokenPath: "/var/run/secrets/ais/activemq/token"
+      # Optional audience for the token.
+      audience: ""
+      # Token expiry in seconds (Kubernetes will rotate/refresh the projected token automatically).
+      expirationSeconds: 3600
   # Uncomment OHIF viewer line below for XNAT 1.8.2 and higher
   #ohif-viewer: {}
   #ldap-auth-plugin:

--- a/releases/xnat/values.yaml
+++ b/releases/xnat/values.yaml
@@ -150,6 +150,18 @@ xnat-web:
 
   plugins: {}
     #container-service: []
+
+  # ActiveMQ client configuration (Issue #175)
+  activemq:
+    enabled: false
+    brokerUrl: ""
+    user: ""
+    auth:
+      mode: basic # basic|serviceAccountJwt
+      serviceAccountJwt:
+        tokenPath: "/var/run/secrets/ais/activemq/token"
+        audience: ""
+        expirationSeconds: 3600
     # Uncomment OHIF viewer line below for XNAT 1.8.2 and higher
     #ohif-viewer: {}
     #ldap-auth-plugin:


### PR DESCRIPTION
Summary

Add Helm chart support to configure Spring ActiveMQ client settings and enable JWT bearer-style authentication using a projected Kubernetes ServiceAccount token.

This approach avoids storing tokens in Kubernetes Secrets by reading credentials directly from the projected token file.

Changes

Add new Helm values for ActiveMQ configuration

Includes support for umbrella chart pass-through

Mount a projected Kubernetes ServiceAccount token to a configurable file path

Configure Tomcat to load spring.activemq.password from the mounted token file

Update documentation with configuration details and usage guidance

Notes

Kubernetes automatically rotates the projected ServiceAccount token.

To fully benefit from token rotation, the application must properly reconnect and/or reload credentials when the token changes.

Fixes: Australian-Imaging-Service/charts#175