### PR TITLE
feat(xnat-web): Gateway API resources as ingress alternative

### DIFF
--- a/releases/xnat/charts/xnat-web/README.md
+++ b/releases/xnat/charts/xnat-web/README.md
@@ -2,6 +2,19 @@
 
 ## Parameters
 
+## Gateway API (Issue #176)
+
+This chart can generate Gateway API resources (`Gateway` and `HTTPRoute`) as an alternative to Kubernetes `Ingress`.
+
+Enable it with:
+
+- `gateway.enabled=true`
+- `ingress.enabled=false`
+
+Notes:
+- Gateway API CRDs (`gateway.networking.k8s.io/v1beta1`) must be installed in the cluster.
+- If `gateway.existingGatewayName` is set, the chart will not create a `Gateway` and will instead attach the `HTTPRoute` to the named existing Gateway.
+
 The following tables list the configuration parameters of the XNAT-web Chart and their default values.
 
 | Parameter                                   | Description                                                                          | Default |

--- a/releases/xnat/charts/xnat-web/templates/gateway.yaml
+++ b/releases/xnat/charts/xnat-web/templates/gateway.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.gateway.enabled -}}
+{{- if .Values.ingress.enabled -}}
+{{- fail "xnat-web: gateway.enabled and ingress.enabled cannot both be true" -}}
+{{- end -}}
+{{- if not (.Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1beta1") -}}
+{{- fail "xnat-web: Gateway API not available (missing gateway.networking.k8s.io/v1beta1). Install Gateway API CRDs or disable gateway.enabled" -}}
+{{- end -}}
+{{- if not .Values.gateway.existingGatewayName -}}
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
+  name: {{ include "xnat-web.fullname" . }}
+  labels:
+    {{- include "xnat-web.labels" . | nindent 4 }}
+  {{- with .Values.gateway.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  gatewayClassName: {{ required "xnat-web: gateway.gatewayClassName is required when creating a Gateway" .Values.gateway.gatewayClassName | quote }}
+  listeners:
+    {{- range .Values.gateway.listeners }}
+    - name: {{ .name | quote }}
+      protocol: {{ .protocol | quote }}
+      port: {{ .port }}
+      {{- if .hostname }}
+      hostname: {{ .hostname | quote }}
+      {{- end }}
+      {{- if $.Values.gateway.tls.enabled }}
+      tls:
+        mode: Terminate
+        certificateRefs:
+          {{- toYaml $.Values.gateway.tls.certificateRefs | nindent 10 }}
+      {{- end }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/releases/xnat/charts/xnat-web/templates/httproute.yaml
+++ b/releases/xnat/charts/xnat-web/templates/httproute.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.gateway.enabled -}}
+{{- if .Values.ingress.enabled -}}
+{{- fail "xnat-web: gateway.enabled and ingress.enabled cannot both be true" -}}
+{{- end -}}
+{{- if not (.Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1beta1") -}}
+{{- fail "xnat-web: Gateway API not available (missing gateway.networking.k8s.io/v1beta1). Install Gateway API CRDs or disable gateway.enabled" -}}
+{{- end -}}
+{{- if .Values.gateway.httpRoute.enabled -}}
+{{- $fullName := include "xnat-web.fullname" . -}}
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "xnat-web.labels" . | nindent 4 }}
+spec:
+  parentRefs:
+    - name: {{ default $fullName .Values.gateway.existingGatewayName | quote }}
+  {{- $hosts := .Values.gateway.httpRoute.hostnames }}
+  {{- if not $hosts }}
+    {{- $hosts = (pluck "host" .Values.ingress.hosts) }}
+  {{- end }}
+  {{- if $hosts }}
+  hostnames:
+    {{- range $hosts }}
+    - {{ . | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+    - matches:
+        {{- toYaml .Values.gateway.httpRoute.matches | nindent 8 }}
+      backendRefs:
+        - name: {{ $fullName }}-headless
+          port: {{ .Values.service.port }}
+{{- end }}
+{{- end }}

--- a/releases/xnat/charts/xnat-web/templates/ingress.yaml
+++ b/releases/xnat/charts/xnat-web/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ingress.enabled -}}
+{{- if and .Values.ingress.enabled (not .Values.gateway.enabled) -}}
 {{- $fullName := include "xnat-web.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
 {{- if semverCompare ">=1.14-0 <=1.21-0" .Capabilities.KubeVersion.GitVersion -}}

--- a/releases/xnat/charts/xnat-web/values.yaml
+++ b/releases/xnat/charts/xnat-web/values.yaml
@@ -57,6 +57,41 @@ ingress:
   enabled: false
   annotations: {}
     # kubernetes.io/tls-acme: "true"
+
+# Gateway API (Issue #176)
+# Enables Gateway/HTTPRoute resources as an alternative to Ingress.
+# NOTE: `gateway.networking.k8s.io` CRDs must be installed in the cluster.
+# This is intended as a drop-in replacement for ingress routing.
+#
+# Safety: do not enable both ingress.enabled and gateway.enabled.
+gateway:
+  enabled: false
+  annotations: {}
+  # If set, do not create a Gateway; instead attach the HTTPRoute to an existing Gateway.
+  existingGatewayName: ""
+  # Required when creating a Gateway.
+  gatewayClassName: ""
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      hostname: "" # optional
+  tls:
+    enabled: false
+    # Example certificateRefs:
+    # - kind: Secret
+    #   name: chart-example-tls
+    certificateRefs: []
+
+  httpRoute:
+    enabled: true
+    # Optional hostnames for HTTPRoute. When empty, falls back to ingress.hosts[].host.
+    hostnames: []
+    # Default match: PathPrefix /
+    matches:
+      - path:
+          type: PathPrefix
+          value: /
     # nginx.ingress.kubernetes.io/whitelist-source-range: "130.95.0.0/16"
     # nginx.ingress.kubernetes.io/proxy-connect-timeout: "150"
     # nginx.ingress.kubernetes.io/proxy-send-timeout: "100"

--- a/releases/xnat/values.yaml
+++ b/releases/xnat/values.yaml
@@ -83,6 +83,28 @@ xnat-web:
   ingress:
     enabled: false
     annotations: {}
+
+  # Gateway API (Issue #176)
+  gateway:
+    enabled: false
+    annotations: {}
+    existingGatewayName: ""
+    gatewayClassName: ""
+    listeners:
+      - name: http
+        protocol: HTTP
+        port: 80
+        hostname: ""
+    tls:
+      enabled: false
+      certificateRefs: []
+    httpRoute:
+      enabled: true
+      hostnames: []
+      matches:
+        - path:
+            type: PathPrefix
+            value: /
       # kubernetes.io/tls-acme: "true"
       # nginx.ingress.kubernetes.io/whitelist-source-range: "130.95.0.0/16"
       # nginx.ingress.kubernetes.io/proxy-connect-timeout: "150"


### PR DESCRIPTION
Summary

Add optional Kubernetes Gateway API resources (Gateway and HTTPRoute) to the XNAT web chart as an alternative to using Ingress.

This enables deployments that rely on the Gateway API while maintaining backward compatibility with existing Ingress-based setups.

Changes

Add new Helm values for Gateway configuration

Includes xnat-web chart values

Supports umbrella chart pass-through

Add new templates:

gateway.yaml

httproute.yaml

Ensure Ingress is not rendered when Gateway is enabled

Fail fast if both Ingress and Gateway are enabled simultaneously

Document basic configuration and usage

Usage

Enable Gateway support by setting:

xnatWeb.gateway.enabled=true

xnatWeb.gateway.create=true (if creating a new Gateway)

If you are attaching to an existing shared Gateway, set:

xnatWeb.gateway.create=false

This will create only the HTTPRoute and bind it to the existing Gateway.

Fixes: #176