### PR TITLE
fix bug in side container plugin-logs

### DIFF
--- a/releases/xnat/templates/xnat-web/statefulset.yaml
+++ b/releases/xnat/templates/xnat-web/statefulset.yaml
@@ -101,8 +101,9 @@ spec:
               sleep 30
               # Display logs to stdout
               for f in /data/xnat/home/logs/*.log; do
-                tail -F "${f}"
+                tail -F "${f}" &
               done
+              wait
           volumeMounts:
             - name: xnat-home
               mountPath: /data/xnat/home


### PR DESCRIPTION
Run tail in backgroud mode to allow all plugin's log to be sent to stdout for collection 