### PR TITLE
Use debian:stable-slim for XNAT plugin-logs and CTP ctp-logstream containers

### DIFF
--- a/releases/ctp/templates/deployment.yaml
+++ b/releases/ctp/templates/deployment.yaml
@@ -74,7 +74,7 @@ spec:
         - name: {{ .Chart.Name }}-logstream
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: alpine
+          image: debian:stable-slim
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args: ["/bin/sh", "-c", "tail -f /JavaPrograms/CTP/logs/ctp.log"]
           volumeMounts:

--- a/releases/xnat/templates/xnat-web/statefulset.yaml
+++ b/releases/xnat/templates/xnat-web/statefulset.yaml
@@ -89,7 +89,7 @@ spec:
         - name: plugin-logs
           securityContext:
             {{- toYaml .securityContext | nindent 12 }}
-          image: debian:bullseye-slim
+          image: debian:stable-slim
           imagePullPolicy: {{ .image.pullPolicy }}
           command: [bash, -c]
           args:


### PR DESCRIPTION
XNAT chart plugin-logs container pinned to `debian:bullseye-slim` which is currently two major versions behind Debian Stable.

There isn't a strong reason for using alpine as a different minimal image for similar CTP logfile tail-ing container.

