### PR TITLE
ctp: include PVC .spec.selector only if defined in values

### DIFF
--- a/releases/ctp/templates/pvc.yaml
+++ b/releases/ctp/templates/pvc.yaml
@@ -17,8 +17,9 @@ spec:
   {{- if $v.storageClassName }}
   storageClassName: {{ $v.storageClassName }}
   {{- end }}
+  {{- if $v.selector }}
   selector:
-    matchLabels: {}
-    matchExpressions: []
+   {{- toYaml $v.selector  | nindent 4 }}
+  {{- end }}
 {{- end }}
 {{- end }}

--- a/releases/ctp/values.yaml
+++ b/releases/ctp/values.yaml
@@ -158,6 +158,9 @@ volumes:
     mountPath: "/vol/roots"
     # storageClassName: "-"
     size: 10Gi
+    # selector:
+    #   matchLabels: {}
+    #   matchExpressions: []
   # quarantines:
   #   accessMode: ReadWriteMany
   #   #existingClaim: ""


### PR DESCRIPTION
Not all CSI options support this, e.g. EBS CSI driver fails to provision with an empty selector element