### PR TITLE
ctp: use ingressClassName if defined in values

### DIFF
--- a/releases/ctp/templates/ingress.yaml
+++ b/releases/ctp/templates/ingress.yaml
@@ -45,7 +45,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  ingressClassName: nginx
+  {{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+  {{- end }}
   {{- if .Values.ingress.tls }}
   tls:
     {{- range .Values.ingress.tls }}

--- a/releases/ctp/values.yaml
+++ b/releases/ctp/values.yaml
@@ -60,8 +60,8 @@ services:
 
 ingress:
   enabled: false
+  # ingressClassName: nginx
   annotations: {}
-    # kubernetes.io/ingress.class: "nginx"
     # kubernetes.io/tls-acme: "true"
     # nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
   hosts: []


### PR DESCRIPTION
- Use ingressClassName if defined in values
- Remove hardcoded 'ingressClassName: nginx'
- Add ingressClassname to values.yaml